### PR TITLE
doc(readme): update Op to filter by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ A versão web do projeto FastFeet representa a visão da distribuidora, ou seja,
 
 Antes de iniciar a parte web, **adicione as seguintes funcionalidades no back-end** da aplicação:
 
-1. Permita que a listagem de encomendas seja filtrada pelo nome do produto, recebendo um Query Parameter `?q=Piano` e buscando no banco encomendas com esse filtro (utilize o operador `like`). Caso o parâmetro não seja passado, retorne todas as encomendas;
+1. Permita que a listagem de encomendas seja filtrada pelo nome do produto, recebendo um Query Parameter `?q=Piano` e buscando no banco encomendas com esse filtro (utilize os operadores `Like` ou `iLike`). Caso o parâmetro não seja passado, retorne todas as encomendas;
 
-2. Permita que a listagem de entregadores seja filtrada pelo nome do entregador, recebendo um Query Parameter `?q=John` e buscando no banco entregadores com esse filtro (utilize o operador `like`). Caso o parâmetro não seja passado, retorne todos entregadores;
+2. Permita que a listagem de entregadores seja filtrada pelo nome do entregador, recebendo um Query Parameter `?q=John` e buscando no banco entregadores com esse filtro (utilize os operadores `Like` ou `iLike`). Caso o parâmetro não seja passado, retorne todos entregadores;
 
-3. Permita que a listagem de destinatários seja filtrada pelo nome do destinatário, recebendo um Query Parameter `?q=Ludwig` e buscando no banco destinatários com esse filtro (utilize o operador `like`). Caso o parâmetro não seja passado, retorne todos entregadores;
+3. Permita que a listagem de destinatários seja filtrada pelo nome do destinatário, recebendo um Query Parameter `?q=Ludwig` e buscando no banco destinatários com esse filtro (utilize os operadores `Like` ou `iLike`). Caso o parâmetro não seja passado, retorne todos entregadores;
 
 ### Informações importantes
 


### PR DESCRIPTION
Hi Devs,

I suggest this PR to increment the iLike operator. Why?
The `Like` operator is case sensitive, so if the delivery has a product with name **Piano** and the user try to filter by **piano**, the result will be empty.
With the `iLike` operator, he is free to search how he wants, because it is case insensitive.